### PR TITLE
Fix duplicate URL slugs

### DIFF
--- a/app/code/community/Emico/Tweakwise/Model/Catalog/Layer.php
+++ b/app/code/community/Emico/Tweakwise/Model/Catalog/Layer.php
@@ -338,7 +338,7 @@ class Emico_Tweakwise_Model_Catalog_Layer
         foreach ($this->getFacets() as $facet) {
             foreach ($facet->getAttributes() as $attribute) {
                 if ($attribute->getIsSelected()) {
-                    $selectedFacets[] = $facet;
+                    $selectedFacets[$facet->getId()] = $facet;
                 }
             }
         }


### PR DESCRIPTION
Make sure a unique facet is only returned once. Otherwise the same facet would be appended to the URL path multiple times