### PR TITLE
Issue/multiple queries for category urls

### DIFF
--- a/app/code/community/Emico/Tweakwise/Helper/Data.php
+++ b/app/code/community/Emico/Tweakwise/Helper/Data.php
@@ -253,8 +253,9 @@ class Emico_Tweakwise_Helper_Data extends Mage_Core_Helper_Abstract
         }
 
         if (!($category = $this->_categoryCollection->getItemById($categoryId))) {
-            $category = Mage::getResourceModel('catalog/category_collection')
-                ->addAttributeToSelect(['*'])
+            $category = Mage::getModel('catalog/category')->getCollection()
+                ->addAttributeToSelect('*')
+                ->joinUrlRewrite()
                 ->addFieldToFilter('entity_id', ['eq' => $categoryId])
                 ->getFirstItem();
             $this->_categoryCollection->addItem($category);

--- a/app/code/community/Emico/Tweakwise/Model/Layout/Observer.php
+++ b/app/code/community/Emico/Tweakwise/Model/Layout/Observer.php
@@ -72,6 +72,7 @@ class Emico_Tweakwise_Model_Layout_Observer
         );
 
         return Mage::getModel('catalog/category')->getCollection()
+            ->addAttributeToSelect('*')
             ->addFieldToFilter('entity_id', ['in' => $categoryIds])
             ->joinUrlRewrite()
             ->getItems();

--- a/app/code/community/Emico/Tweakwise/Model/Layout/Observer.php
+++ b/app/code/community/Emico/Tweakwise/Model/Layout/Observer.php
@@ -12,6 +12,10 @@ class Emico_Tweakwise_Model_Layout_Observer
      */
     public function loadCategoryData(Varien_Event_Observer $observer)
     {
+        $tweakwiseHelper = Mage::helper('emico_tweakwise');
+        if (!$tweakwiseHelper->isEnabled('navigation', Mage::app()->getStore())) {
+            return;
+        }
         /** @var Emico_Tweakwise_Model_Catalog_Layer $layer */
         $layer = Mage::getSingleton('emico_tweakwise/catalog_layer');
         if (!$layer->hasTweakwiseResponse()) {
@@ -24,8 +28,6 @@ class Emico_Tweakwise_Model_Layout_Observer
             return;
         }
         $categories = $this->getMagentoCategories($categoryFacet);
-
-        $tweakwiseHelper = Mage::helper('emico_tweakwise');
         // Initialise all used categories for faster access in templates
         $tweakwiseHelper->addToCategoryCollection($categories);
     }


### PR DESCRIPTION
Check if navigation is enabled for current store before loading all category data on helper.
Made category loading consistent, the helper: emico_tweakwise/data loaded category objects differently than the layout observer (emico_tweakwise/layout_observer) this is now fixed.