### PR TITLE
Set the correct template to the upsell filter on category level

### DIFF
--- a/app/code/community/Emico/Tweakwise/etc/config.xml
+++ b/app/code/community/Emico/Tweakwise/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Emico_Tweakwise>
-            <version>1.12.0</version>
+            <version>1.12.1</version>
         </Emico_Tweakwise>
     </modules>
     <global>

--- a/app/code/community/Emico/Tweakwise/sql/emico_tweakwise_setup/mysql4-upgrade-1.12.0-1.12.1.php
+++ b/app/code/community/Emico/Tweakwise/sql/emico_tweakwise_setup/mysql4-upgrade-1.12.0-1.12.1.php
@@ -1,0 +1,19 @@
+<?php
+/** @var Mage_Core_Model_Resource_Setup $installer */
+
+$installer = $this;
+
+$installer->startSetup();
+
+try {
+    /** @var Mage_Eav_Model_Attribute $attribute */
+    $attribute = Mage::getModel('eav/entity_attribute');
+    $attribute->loadByCode(Mage_Catalog_Model_Category::ENTITY, 'tweakwise_upsell_template');
+
+    $attribute->setData('source_model', 'emico_tweakwise/system_config_source_recommendationProduct');
+    $attribute->save();
+} catch (Exception $e) {
+    die('Unable to update source_model for the attribute');
+}
+
+$installer->endSetup();


### PR DESCRIPTION
For the recommendations it's possible to set a template on global
level (Magento configuration), product level (attribute) and category
level (attribute). For the category an incorrect source model was used.
It uses `emico_tweakwise/system_config_source_recommendationFeatured`,
where it should use `emico_tweakwise/system_config_source_recommendationProduct`.
With a new install script this bug can be fixed, so it's possible
to select the correct upsell template on category level as well.