### PR TITLE
Get filtered query from helper

### DIFF
--- a/app/code/community/Emico/Tweakwise/Block/Catalog/Layer/Facet/Category.php
+++ b/app/code/community/Emico/Tweakwise/Block/Catalog/Layer/Facet/Category.php
@@ -28,7 +28,7 @@ class Emico_Tweakwise_Block_Catalog_Layer_Facet_Category extends Emico_Tweakwise
     public function getFacetUrl(Emico_Tweakwise_Model_Bus_Type_Attribute $attribute, $urlKey = null)
     {
         $helper = Mage::helper('emico_tweakwise');
-        $query = $this->getFilteredQuery();
+        $query = $helper->getFilteredQuery();
         $category = $helper->getFilterCategory($attribute->getAttributeId());
         $query['p'] = null;
         $query['ajax'] = null;


### PR DESCRIPTION
https://github.com/EmicoEcommerce/Magento1Tweakwise/commit/082d5dd33faf488dafc7904f8e26366daf24bbb0
In this commit on 9 may 2018 the method `getFilteredQuery` was added to the `Emico_Tweakwise_Block_Catalog_Layer_Facet_Category` class.

https://github.com/EmicoEcommerce/Magento1Tweakwise/commit/477b04dc46fb2cf5fd8311a3811be18f47118066#diff-aa19e49f3e6d5c8b1180c35d8b26fa37
On this commit on 23 May 2018 this method was removed again and added to the helper. But on line 31 it still points to $this and fires the magic function for GET.

We need to use the helper in order to keep the current queries of the requested url.