### PR TITLE
Improve performance of rel="no-follow "generation in attributes template

### DIFF
--- a/app/code/community/Emico/Tweakwise/Helper/Seo.php
+++ b/app/code/community/Emico/Tweakwise/Helper/Seo.php
@@ -59,15 +59,18 @@ class Emico_Tweakwise_Helper_Seo extends Mage_Core_Helper_Abstract
      */
     protected function isInFacetBlacklist(Emico_Tweakwise_Model_Bus_Type_Facet $facetLinkedTo = null)
     {
-        $layer = Mage::getSingleton('emico_tweakwise/catalog_layer');
-        $noFollowFacets = explode(',', Mage::getStoreConfig('emico_tweakwise/navigation/nofollow_facets'));
-        $selectedFacets = $layer->getSelectedFacets();
-        if ($facetLinkedTo !== null) {
-            $selectedFacets[] = $facetLinkedTo;
-        }
+        $noFollowFacets = array_filter(explode(',', Mage::getStoreConfig('emico_tweakwise/navigation/nofollow_facets')));
 
-        foreach ($selectedFacets as $facet) {
-            if (in_array($facet->getFacetSettings()->getUrlKey(), $noFollowFacets)) {
+        if ($facetLinkedTo !== null && in_array($facetLinkedTo->getFacetSettings()->getUrlKey(), $noFollowFacets)) {
+            return true;
+        }
+        $layer = Mage::getSingleton('emico_tweakwise/catalog_layer');
+
+        foreach ($layer->getFacets() as $facet) {
+            if (!in_array($facet->getFacetSettings()->getUrlKey(), $noFollowFacets)) {
+                continue;
+            }
+            if ($facet->hasActiveAttributes()) {
                 return true;
             }
         }

--- a/app/code/community/Emico/Tweakwise/Model/Bus/Type/Facet.php
+++ b/app/code/community/Emico/Tweakwise/Model/Bus/Type/Facet.php
@@ -48,6 +48,19 @@ class Emico_Tweakwise_Model_Bus_Type_Facet extends Emico_Tweakwise_Model_Bus_Typ
     }
 
     /**
+     * @return bool
+     */
+    public function hasActiveAttributes()
+    {
+        foreach ($this->getAttributes() as $attribute) {
+            if ($attribute->getIsSelected()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @return Emico_Tweakwise_Model_Bus_Type_Attribute[]
      */
     public function getActiveAttributes()

--- a/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/attribute.phtml
+++ b/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/attribute.phtml
@@ -14,11 +14,12 @@
 
 
         <?php $_attributes = $this->getAttributes(); ?>
+        <?php $_hrefAttributes = $this->getHrefAttributes(); ?>
         <ol>
             <?php foreach ($_attributes as $_item): ?>
                 <?php $_showLink = !$_item->getIsSelected() || $this->isCheckbox(); ?>
                 <li class="<?php echo $_item->getIsSelected() ? 'active' : 'inactive'; echo $this->isMoreItem($_item) ? ' hidden' : ''; echo $this->isCheckbox() ? ' checkbox' : ''; ?>">
-                    <a<?php if($_showLink): ?> href="<?php echo $this->escapeUrl($this->getFacetUrl($_item)) ?>"<?php endif; ?> title="<?=$this->escapeHtml($this->getItemTitle($_item))?>"<?=$this->getHrefAttributes()?>>
+                    <a<?php if($_showLink): ?> href="<?php echo $this->escapeUrl($this->getFacetUrl($_item)) ?>"<?php endif; ?> title="<?=$this->escapeHtml($this->getItemTitle($_item))?>"<?=$_hrefAttributes?>>
                         <?php echo $this->escapeHtml($this->getItemTitle($_item)); ?>
                         <?php if ($_settings->getIsNumberOfResultVisible()): ?>
                             (<?php echo $_item->getNumberOfResults() ?>)


### PR DESCRIPTION
This PR improves performance of the generation of `rel="no-follow"` in the `app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/attribute.phtml` template by a combination of the following:

1. Calculate the href attributes once per facet instead of once for every facet attribute.
2. Improve performance of `Emico_Tweakwise_Helper_Seo::isInFacetBlacklist` by avoiding useless calculations.

When testing these changes, worst-case performance of pages containing many facet attributes went down from multiple seconds to well below 1 second.

This fixes issue #32.