### PR TITLE
Improve performance of rendering the 'hidden' class in attributes templates

### DIFF
--- a/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/attribute.phtml
+++ b/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/attribute.phtml
@@ -14,10 +14,11 @@
 
 
         <?php $_attributes = $this->getAttributes(); ?>
+        <?php $_numberOfShownAttributes = 0; ?>
         <ol>
             <?php foreach ($_attributes as $_item): ?>
                 <?php $_showLink = !$_item->getIsSelected() || $this->isCheckbox(); ?>
-                <li class="<?php echo $_item->getIsSelected() ? 'active' : 'inactive'; echo $this->isMoreItem($_item) ? ' hidden' : ''; echo $this->isCheckbox() ? ' checkbox' : ''; ?>">
+                <li class="<?php echo $_item->getIsSelected() ? 'active' : 'inactive'; echo ($_numberOfShownAttributes >= $_settings->getNumberOfShownAttributes()) ? ' hidden' : ''; echo $this->isCheckbox() ? ' checkbox' : ''; ?>">
                     <a<?php if($_showLink): ?> href="<?php echo $this->escapeUrl($this->getFacetUrl($_item)) ?>"<?php endif; ?> title="<?=$this->escapeHtml($this->getItemTitle($_item))?>"<?=$this->getHrefAttributes()?>>
                         <?php echo $this->escapeHtml($this->getItemTitle($_item)); ?>
                         <?php if ($_settings->getIsNumberOfResultVisible()): ?>
@@ -25,6 +26,7 @@
                         <?php endif; ?>
                     </a>
                 </li>
+                <?php $_numberOfShownAttributes += 1 ?>
             <?php endforeach ?>
             <?php if($this->showMoreText()): ?>
                 <li class="more-less-links">

--- a/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/swatch/css.phtml
+++ b/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/swatch/css.phtml
@@ -14,10 +14,11 @@
         <?php endif; ?>
 
         <?php $_attributes = $this->getAttributes(); ?>
+        <?php $_numberOfShownAttributes = 0; ?>
         <ol class="swatches">
             <?php foreach ($_attributes as $_item): ?>
                 <?php $_showLink = !$_item->getIsSelected() || $this->isCheckbox(); ?>
-                <li class="<?php echo $_item->getIsSelected() ? 'active' : 'inactive'; echo $this->isMoreItem($_item) ? ' hidden' : ''; echo $this->isCheckbox() ? ' checkbox' : ''; ?>">
+                <li class="<?php echo $_item->getIsSelected() ? 'active' : 'inactive'; echo ($_numberOfShownAttributes >= $_settings->getNumberOfShownAttributes()) ? ' hidden' : ''; echo $this->isCheckbox() ? ' checkbox' : ''; ?>">
                     <span class="color-holder color-<?=strtolower($this->escapeHtml($_item->getTitle()));?>">
                         <a<?php if($_showLink): ?> href="<?php echo $this->escapeUrl($this->getFacetUrl($_item)) ?>" title="<?=$this->escapeHtml($_item->getTitle())?>"<?php endif; ?>><span class="color">&nbsp;</span></a>
                     </span>
@@ -28,6 +29,7 @@
                         <?php endif; ?>
                     </a>
                 </li>
+                <?php $_numberOfShownAttributes += 1 ?>
             <?php endforeach ?>
             <?php if($this->showMoreText()): ?>
                 <li class="more-less-links">

--- a/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/tree/items.phtml
+++ b/app/design/frontend/base/default/template/emico_tweakwise/catalog/layer/facet/tree/items.phtml
@@ -1,6 +1,7 @@
 <?php /** @var $this Emico_Tweakwise_Block_Catalog_Layer_Facet_Tree_Items */ ?>
 <?php $_attributes = $this->getAttributes(); ?>
 <?php $_settings = $this->getFacetSettings(); ?>
+<?php $_numberOfShownAttributes = 0; ?>
 <ol>
     <?php foreach ($_attributes as $_item): /** @var $_item Emico_Tweakwise_Model_Bus_Type_Attribute */ ?>
         <?php $_showLink = $this->isShowLink($_item);
@@ -11,7 +12,7 @@
         }
 
         ?>
-        <li class="<?php echo $_item->getIsSelected() ? 'active' : 'inactive'; echo $this->isMoreItem($_item) ? ' hidden' : ''; echo $this->isCheckbox() ? ' checkbox' : ''; ?>">
+        <li class="<?php echo $_item->getIsSelected() ? 'active' : 'inactive'; echo ($_numberOfShownAttributes >= $_settings->getNumberOfShownAttributes()) ? ' hidden' : ''; echo $this->isCheckbox() ? ' checkbox' : ''; ?>">
             <a<?php if($_showLink): ?> href="<?php echo $this->escapeUrl($this->getFacetUrl($_item)) ?>"<?php endif; ?>>
                 <?php echo $this->getItemTitle($_item); ?>
                 <?php if ($_settings->getIsNumberOfResultVisible()): ?>
@@ -23,5 +24,6 @@
                 <?php echo $this->getChildrenTreeHtml($_item); ?>
             <?php endif; ?>
         </li>
+        <?php $_numberOfShownAttributes += 1 ?>
     <?php endforeach ?>
 </ol>


### PR DESCRIPTION
This PR improves performance of the generation of `hidden` classes in attributes templates, by avoiding the use of the relatively expensive `Emico_Tweakwise_Block_Catalog_Layer_Facet_Attribute::isMoreItem` method. Instead of this method, a simple counter is used to determine the number of shown items.

When testing these changes on pages containing many facet attributes, performance of generating the `hidden` classes went down from tens of milliseconds per facet to 0 milliseconds.

This fixes issue #34.