### PR TITLE
Allow empty values for the `navigation/nofollow_facets` system configuration setting

### DIFF
--- a/app/code/community/Emico/Tweakwise/etc/system.xml
+++ b/app/code/community/Emico/Tweakwise/etc/system.xml
@@ -199,6 +199,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <can_be_empty>1</can_be_empty>
                             <comment></comment>
                         </nofollow_facets>
                         <ignored_query_parameters>


### PR DESCRIPTION
Add the `<can_be_empty>1</can_be_empty>` property to the definition of the `emico_tweakwise/navigation/nofollow_facets` system configuration setting. Without this property, the setting cannot be cleared, which should always be possible, since the setting is populated with no selected values.

This PR fixes issue #36.