### PR TITLE
Remove double update of input values on change

### DIFF
--- a/skin/frontend/base/default/emico_tweakwise/js/AttributeSlider.js
+++ b/skin/frontend/base/default/emico_tweakwise/js/AttributeSlider.js
@@ -168,11 +168,10 @@ TweakwiseAttributeSlider.prototype = {
                     {
                         this.updateSlider(value);
                     }.bind(this),
-                    onChange: function(value)
+                    onChange: function()
                     {
                         if(this.initialized)
                         {
-                            this.updateSlider(value);
                             this.getUpdateLink().simulate('click');
                         }
                     }.bind(this)


### PR DESCRIPTION
Removed (double) conflicting value update for the price slider. To fix the following bug:

- Go to: https://tweakwise1-ce.emico.nl/women/new-arrivals.html
- Fill in 400 in the max value input field of the price slider
- The value of the max input field jumps back to the original value (715) 
- The price filter is set to the wrong values (see url)

The removed method updated the fields with the old values and was conflicting with the value update in the input change handler here: https://github.com/EmicoEcommerce/Magento1Tweakwise/blob/master/skin/frontend/base/default/emico_tweakwise/js/AttributeSlider.js#L289 
And in case of using the slider to adjust the values, the value update here: https://github.com/EmicoEcommerce/Magento1Tweakwise/blob/master/skin/frontend/base/default/emico_tweakwise/js/AttributeSlider.js#L169